### PR TITLE
Upgrade libraries with security vulnerabilities for 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.1.1</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>
@@ -28,7 +28,7 @@
         <idam.api-spec.version>2.5.0</idam.api-spec.version>
         <idam.event.version>1.0.14-258</idam.event.version>
         <idam.spi.version>1.0.14-258</idam.spi.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <javax-json.version>1.1</javax-json.version>
         <jjwt.version>0.6.0</jjwt.version>
         <json-patch.version>1.9</json-patch.version>
@@ -43,7 +43,7 @@
         <rest-assured.version>2.3.3</rest-assured.version>
         <retrofit.version>2.3.0</retrofit.version>
         <servlet.version>2.5</servlet.version>
-        <spring.boot.version>1.5.15.RELEASE</spring.boot.version>
+        <spring.boot.version>1.5.19.RELEASE</spring.boot.version>
         <springfox-swagger.version>2.7.0</springfox-swagger.version>
         <swagger.version>1.5.16</swagger.version>
         <spring.cloud.feign.version>1.4.5.RELEASE</spring.cloud.feign.version>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Upgrade Jackson and Spring Boot to versions not affected by 
* CVE-2018-1000873
* CVE-2018-14718
* CVE-2018-14719
* CVE-2018-14720
* CVE-2018-14721
* CVE-2018-19360
* CVE-2018-19361
* CVE-2018-19362

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
