### PR TITLE
increased spring boot version to 2.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>1.5.6</version>
+    <version>1.5.7</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>
@@ -43,7 +43,7 @@
         <rest-assured.version>2.3.3</rest-assured.version>
         <retrofit.version>2.3.0</retrofit.version>
         <servlet.version>2.5</servlet.version>
-        <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
+        <spring.boot.version>2.1.4.RELEASE</spring.boot.version>
         <springfox-swagger.version>2.9.2</springfox-swagger.version>
         <swagger.version>1.5.22</swagger.version>
         <spring.cloud.feign.version>2.1.0.RELEASE</spring.cloud.feign.version>


### PR DESCRIPTION
### Change description ###

increased spring boot version to 2.1.4
This upgrade will include new version of spring security (5.1.5) which will fix vulnerability CVE-2019-3795

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
