### PR TITLE
fix an api build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>
@@ -240,6 +240,11 @@
                 <groupId>io.github.openfeign.form</groupId>
                 <artifactId>feign-form-spring</artifactId>
                 <version>${feign.form.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-jackson</artifactId>
+                <version>10.11</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <swagger.version>1.5.22</swagger.version>
         <feign.httpclient.version>10.2.0</feign.httpclient.version>
         <feign.form.version>3.7.0</feign.form.version>
+        <feign.jackson.version>10.11</feign.jackson.version>
         <oltu.version>1.0.1</oltu.version>
         <brsanthu.migbase64.version>2.2</brsanthu.migbase64.version>
         <forgerock.http.client.version>2.1.0</forgerock.http.client.version>
@@ -244,7 +245,7 @@
             <dependency>
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-jackson</artifactId>
-                <version>10.11</version>
+                <version>${feign.jackson.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,8 @@
         <retrofit.version>2.3.0</retrofit.version>
         <springfox-swagger.version>2.9.2</springfox-swagger.version>
         <swagger.version>1.5.22</swagger.version>
-        <feign.httpclient.version>10.2.0</feign.httpclient.version>
+        <feign.version>10.11.0</feign.version>
         <feign.form.version>3.7.0</feign.form.version>
-        <feign.jackson.version>10.11</feign.jackson.version>
         <oltu.version>1.0.1</oltu.version>
         <brsanthu.migbase64.version>2.2</brsanthu.migbase64.version>
         <forgerock.http.client.version>2.1.0</forgerock.http.client.version>
@@ -212,26 +211,30 @@
             <dependency>
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-httpclient</artifactId>
-                <version>${feign.httpclient.version}</version>
+                <version>${feign.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-core</artifactId>
-                <version>${feign.httpclient.version}</version>
+                <version>${feign.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-okhttp</artifactId>
-                <version>${feign.httpclient.version}</version>
+                <version>${feign.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.openfeign</groupId>
                 <artifactId>feign-slf4j</artifactId>
-                <version>${feign.httpclient.version}</version>
+                <version>${feign.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-jackson</artifactId>
+                <version>${feign.version}</version>
             </dependency>
 
             <!-- OpenFeign form dependencies -->
-
             <dependency>
                 <groupId>io.github.openfeign.form</groupId>
                 <artifactId>feign-form</artifactId>
@@ -241,11 +244,6 @@
                 <groupId>io.github.openfeign.form</groupId>
                 <artifactId>feign-form-spring</artifactId>
                 <version>${feign.form.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.github.openfeign</groupId>
-                <artifactId>feign-jackson</artifactId>
-                <version>${feign.jackson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Change description ###

Fix the following problem when building idam api. 
```
Execution failed for task ‘:idam-spi-forgerock:compileJava’.
> Could not resolve all files for configuration ‘:idam-spi-forgerock:compileClasspath’.
   > Could not find io.github.openfeign:feign-jackson:.
     Required by:
         project :idam-spi-forgerock
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
