### PR TITLE
downgraded fogerock http client as this version only works with idam-api auth trees

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <feign.form.version>3.7.0</feign.form.version>
         <oltu.version>1.0.1</oltu.version>
         <brsanthu.migbase64.version>2.2</brsanthu.migbase64.version>
-        <forgerock.http.client.version>2.2.0</forgerock.http.client.version>
+        <forgerock.http.client.version>2.1.0</forgerock.http.client.version>
         <guava.version>22.0</guava.version>
         <serenity.version>2.0.71</serenity.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>


### PR DESCRIPTION

### Change description ###
downgraded fogerock http client as this version only works with idam-api auth trees, will bump back up in seperate pr when when trees is ready.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
