### PR TITLE
Remove json smart version override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>2.6.3</version>
+    <version>2.6.5</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>
@@ -29,7 +29,6 @@
         <javax-json.version>1.1.4</javax-json.version>
         <jjwt.version>0.6.0</jjwt.version>
         <json-patch.version>1.9</json-patch.version>
-        <json-smart.version>2.3</json-smart.version>
         <notify.version>3.17.0-RELEASE</notify.version>
         <okhttp.mockwebserver.version>3.10.0</okhttp.mockwebserver.version>
         <retrofit.version>2.3.0</retrofit.version>
@@ -92,11 +91,6 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
                 <version>${commons-text.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.minidev</groupId>
-                <artifactId>json-smart</artifactId>
-                <version>${json-smart.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>2.6.5</version>
+    <version>2.6.4</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-6045


### Change description ###
Let json smart version be managed by Spring Boot dependency management.

Note:
Runtime version after this change would 2.3.1.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
