### PR TITLE
Update spring boot version to 2.7.0 for CVE-2022-22976 and CVE-2022-22970

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.hmcts.reform.idam</groupId>
     <artifactId>idam-bom</artifactId>
-    <version>2.8.25</version>
+    <version>2.8.26</version>
     <packaging>pom</packaging>
 
     <name>HMCTS IdAM Platform bill of materials</name>
@@ -14,7 +14,7 @@
 
     <properties>
         <!-- Dependency versions -->
-        <spring.boot.version>2.6.8</spring.boot.version>
+        <spring.boot.version>2.7.0</spring.boot.version>
         <spring.cloud.version>3.1.1</spring.cloud.version>
 
         <!-- Dependency versions -->


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-7706
https://tools.hmcts.net/jira/browse/SIDM-7707
https://tools.hmcts.net/jira/browse/SIDM-7708

### Change description ###

Update spring boot version to 2.7.0 for CVE-2022-22976 and CVE-2022-22970

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
